### PR TITLE
Implementar almacenamiento básico

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,3 @@
+from .live import get_live_price
+
+__all__ = ["get_live_price"]

--- a/api/live.py
+++ b/api/live.py
@@ -1,0 +1,26 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fetchers import PriceFetcher
+from storage import live as live_db
+
+
+def get_live_price(ticker: str, fetcher: PriceFetcher, lock_minutes: int = 15) -> Optional[float]:
+    """Return up-to-date price for ticker using the provided fetcher."""
+    record = live_db.get_price(ticker)
+    now = datetime.utcnow()
+
+    if record:
+        price, updated_at = record
+        if now - updated_at < timedelta(minutes=lock_minutes):
+            return price
+    else:
+        price = None
+
+    new_price = fetcher.get_price(ticker)
+    if new_price is not None:
+        live_db.upsert_price(ticker, new_price, now)
+        return new_price
+
+    # If fetching failed and we had an old price, return it
+    return price

--- a/fetchers/__init__.py
+++ b/fetchers/__init__.py
@@ -1,0 +1,11 @@
+"""Collection of available price fetchers."""
+
+from .base import PriceFetcher
+from .dummy_fetcher import DummyFetcher
+
+try:
+    from .yfinance_fetcher import YFinanceFetcher
+except Exception:  # pragma: no cover - optional dependency
+    YFinanceFetcher = None
+
+__all__ = ["PriceFetcher", "DummyFetcher", "YFinanceFetcher"]

--- a/fetchers/base.py
+++ b/fetchers/base.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+
+class PriceFetcher(ABC):
+    """Interface for price fetchers."""
+
+    @abstractmethod
+    def get_price(self, ticker: str) -> Optional[float]:
+        """Return latest price for ticker or None if not available."""
+        raise NotImplementedError

--- a/fetchers/dummy_fetcher.py
+++ b/fetchers/dummy_fetcher.py
@@ -1,0 +1,11 @@
+from typing import Optional
+import random
+
+from .base import PriceFetcher
+
+
+class DummyFetcher(PriceFetcher):
+    """Return a random price for testing purposes."""
+
+    def get_price(self, ticker: str) -> Optional[float]:
+        return round(random.uniform(1, 100), 2)

--- a/fetchers/yfinance_fetcher.py
+++ b/fetchers/yfinance_fetcher.py
@@ -1,0 +1,16 @@
+from typing import Optional
+import yfinance as yf
+
+from .base import PriceFetcher
+
+
+class YFinanceFetcher(PriceFetcher):
+    """Fetch prices using yfinance."""
+
+    def get_price(self, ticker: str) -> Optional[float]:
+        try:
+            data = yf.Ticker(ticker)
+            price = data.info.get("regularMarketPrice")
+            return float(price) if price is not None else None
+        except Exception:
+            return None

--- a/main.py
+++ b/main.py
@@ -1,4 +1,18 @@
-# Punto de entrada principal para pymrkt
+"""Minimal entry point for pymrkt."""
 
-if __name__ == '__main__':
-    print('Iniciar pymrkt...')
+from fetchers import DummyFetcher
+from api import get_live_price
+from scripts import init_db
+
+
+def main() -> None:
+    init_db.main()
+    fetcher = DummyFetcher()
+
+    for ticker in ["AAPL", "MSFT", "GGAL"]:
+        price = get_live_price(ticker, fetcher, lock_minutes=30)
+        print(ticker, price)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,3 @@
+from . import init_db
+
+__all__ = ["init_db"]

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,3 +1,20 @@
-# Script para inicializar base de datos
+"""Initialize live and historical databases."""
 
-print('Inicializando base de datos...')
+import os
+import sys
+
+# Ensure project root is in path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from storage import live, historical
+
+
+def main() -> None:
+    print("Inicializando bases de datos...")
+    live.init_db()
+    historical.init_db()
+    print("Listo.")
+
+
+if __name__ == "__main__":
+    main()

--- a/storage/historical.py
+++ b/storage/historical.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import sqlite3
+from datetime import date
+from typing import Optional
+
+DB_FILE = Path(__file__).resolve().parent / "historical.db"
+
+
+def init_db() -> None:
+    """Create the historical prices table if it doesn't exist."""
+    conn = sqlite3.connect(DB_FILE)
+    c = conn.cursor()
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ticker TEXT NOT NULL,
+            date TEXT NOT NULL,
+            price REAL NOT NULL,
+            adj_price REAL,
+            volume INTEGER
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def insert_record(ticker: str, d: date, price: float, adj_price: float, volume: int) -> None:
+    conn = sqlite3.connect(DB_FILE)
+    c = conn.cursor()
+    c.execute(
+        """
+        INSERT INTO history (ticker, date, price, adj_price, volume)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (ticker.upper(), d.isoformat(), price, adj_price, volume),
+    )
+    conn.commit()
+    conn.close()

--- a/storage/live.py
+++ b/storage/live.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+import sqlite3
+from datetime import datetime
+from typing import Optional, Tuple
+
+DB_FILE = Path(__file__).resolve().parent / "live.db"
+
+
+def init_db() -> None:
+    """Create the live prices table if it doesn't exist."""
+    conn = sqlite3.connect(DB_FILE)
+    c = conn.cursor()
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS prices (
+            ticker TEXT PRIMARY KEY,
+            price REAL NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_price(ticker: str) -> Optional[Tuple[float, datetime]]:
+    """Return price and timestamp for ticker if available."""
+    conn = sqlite3.connect(DB_FILE)
+    c = conn.cursor()
+    c.execute(
+        "SELECT price, updated_at FROM prices WHERE ticker = ?",
+        (ticker.upper(),),
+    )
+    row = c.fetchone()
+    conn.close()
+    if row:
+        price, ts = row
+        return price, datetime.fromisoformat(ts)
+    return None
+
+
+def upsert_price(ticker: str, price: float, timestamp: Optional[datetime] = None) -> None:
+    """Insert or update price for ticker."""
+    if timestamp is None:
+        timestamp = datetime.utcnow()
+    conn = sqlite3.connect(DB_FILE)
+    c = conn.cursor()
+    c.execute(
+        """
+        INSERT INTO prices (ticker, price, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(ticker) DO UPDATE SET price=excluded.price, updated_at=excluded.updated_at
+        """,
+        (ticker.upper(), price, timestamp.isoformat()),
+    )
+    conn.commit()
+    conn.close()


### PR DESCRIPTION
## Summary
- agregar módulo de storage para base live e histórica
- crear fetchers con implementación dummy/yfinance
- exponer `get_live_price` para actualizar si venció el lock
- script `init_db` inicializa ambas bases
- actualizar `main` para usar la lógica nueva

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python scripts/init_db.py`
- `python main.py`
- `pip install yfinance` *(falla: internet deshabilitado)*

------
https://chatgpt.com/codex/tasks/task_e_6888c1a778808322bab9fdbb87710a00