### PR TITLE
Add gitignore and document fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info/
+
+dist/
+build/
+.eggs/
+
+# Virtual environments
+venv/
+ENV/
+
+# PyCharm
+.idea/
+*.iml
+
+# Logs and databases
+*.log
+*.db
+
+# Local environment variables
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -131,6 +131,27 @@ python scripts/init_db.py
 python main.py
 ```
 
+### Uso de la lógica de fetching
+
+Luego de inicializar las bases de datos, podés obtener precios de forma manual
+llamando a la función `get_live_price` junto con el *fetcher* que prefieras. Por
+ejemplo, utilizando el `DummyFetcher` incluido:
+
+```python
+from fetchers import DummyFetcher
+from api.live import get_live_price
+from scripts.init_db import main as init_db
+
+init_db()
+fetcher = DummyFetcher()
+price = get_live_price("AAPL", fetcher)
+print(price)
+```
+
+El resultado queda almacenado en `storage/live.db`. Si solicitás nuevamente el
+precio antes de que pasen 15 minutos (valor configurable con `lock_minutes`), se
+devolverá el último precio guardado sin contactar al *fetcher*.
+
 ---
 
 ## 🔐 Seguridad


### PR DESCRIPTION
## Summary
- add `.gitignore` to filter Python, PyCharm, venv and DB artifacts
- explain how to use the initial fetching logic in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888cdda70288322aeeb4f142c2b3804