### PR TITLE
Add debug messages on price source

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,16 +1,24 @@
 """Minimal entry point for pymrkt."""
 
+import argparse
+
 from fetchers import DummyFetcher
 from api import get_live_price
 from scripts import init_db
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Run pymrkt")
+    parser.add_argument(
+        "--debug", action="store_true", help="Enable debug output"
+    )
+    args = parser.parse_args()
+
     init_db.main()
     fetcher = DummyFetcher()
 
     for ticker in ["AAPL", "MSFT", "GGAL"]:
-        price = get_live_price(ticker, fetcher, lock_minutes=30)
+        price = get_live_price(ticker, fetcher, lock_minutes=30, debug=args.debug)
         print(ticker, price)
 
 


### PR DESCRIPTION
## Summary
- add a `--debug` flag to `main.py`
- extend `get_live_price` with debug option that prints where prices came from

## Testing
- `python main.py --debug | head -n 20`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888f1d7de888322a3c143de97e26b43