### PR TITLE
Configure lock_minutes via YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Las fuentes posibles incluyen:
 - `dólar blue`, `MEP`, `CCL` (webs públicas)
 - Criptomonedas (Coinbase, Binance)
 
-Los tickers y frecuencia se configuran desde un archivo YAML.
+Los tickers, su frecuencia y el valor de `lock_minutes` se configuran desde un
+archivo YAML (`config/config.yaml`).
 
 ---
 
@@ -156,22 +157,24 @@ print(price)
 ```
 
 El resultado queda almacenado en `storage/live.db`. Si solicitás nuevamente el
-precio antes de que pasen 15 minutos (valor configurable con `lock_minutes`), se
-devolverá el último precio guardado sin contactar al *fetcher*.
+precio antes de que pasen 15 minutos (valor configurable con `lock_minutes` en
+`config/config.yaml`), se devolverá el último precio guardado sin contactar al
+*fetcher*.
 
 ### Configuración del tiempo de *lock*
 
 `get_live_price` acepta un parámetro opcional `lock_minutes` que define cuántos
-minutos deben transcurrir antes de volver a consultar a la fuente de datos. Si
-establecés `lock_minutes=0`, el servicio buscará siempre un precio nuevo en lugar
-de usar el almacenado en la base. Podés ajustarlo a tus necesidades:
+minutos deben transcurrir antes de volver a consultar a la fuente de datos. Por
+defecto este valor se obtiene desde `config/config.yaml`. Si establecés
+`lock_minutes=0`, el servicio buscará siempre un precio nuevo en lugar de usar
+el almacenado en la base. Podés ajustarlo a tus necesidades:
 
 ```python
 price = get_live_price("AAPL", fetcher, lock_minutes=5)
 ```
 
-En el archivo `main.py` se muestra un ejemplo utilizando `lock_minutes=30` para
-reducir la cantidad de llamadas externas.
+En el archivo `main.py` se muestra un ejemplo que utiliza el valor definido en
+`config/config.yaml` para reducir la cantidad de llamadas externas.
 
 ---
 

--- a/api/live.py
+++ b/api/live.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta
 from typing import Optional
 
+from config import get_lock_minutes
+
 from fetchers import PriceFetcher
 from storage import live as live_db
 
@@ -8,10 +10,12 @@ from storage import live as live_db
 def get_live_price(
     ticker: str,
     fetcher: PriceFetcher,
-    lock_minutes: int = 15,
+    lock_minutes: Optional[int] = None,
     debug: bool = False,
 ) -> Optional[float]:
     """Return up-to-date price for ticker using the provided fetcher."""
+    if lock_minutes is None:
+        lock_minutes = get_lock_minutes()
     record = live_db.get_price(ticker)
     now = datetime.utcnow()
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,27 @@
+"""Utilities to load pymrkt configuration."""
+
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+CONFIG_PATH = Path(__file__).resolve().parent / "config.yaml"
+
+
+def _load_config() -> Dict[str, Any]:
+    """Return configuration dictionary from ``config.yaml``."""
+    try:
+        with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh) or {}
+    except FileNotFoundError:
+        return {}
+
+
+def get_lock_minutes() -> int:
+    """Return the ``lock_minutes`` setting from the configuration file."""
+    cfg = _load_config()
+    return int(cfg.get("lock_minutes", 15))
+
+
+__all__ = ["get_lock_minutes"]
+

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,5 @@
 # Configuración de pymrkt
+lock_minutes: 15
 sources:
   - name: yfinance
     enabled: true

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import argparse
 
 from fetchers import DummyFetcher
 from api import get_live_price
+from config import get_lock_minutes
 from scripts import init_db
 
 
@@ -16,9 +17,10 @@ def main() -> None:
 
     init_db.main()
     fetcher = DummyFetcher()
+    lock_minutes = get_lock_minutes()
 
     for ticker in ["AAPL", "MSFT", "GGAL"]:
-        price = get_live_price(ticker, fetcher, lock_minutes=30, debug=args.debug)
+        price = get_live_price(ticker, fetcher, lock_minutes=lock_minutes, debug=args.debug)
         print(ticker, price)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ yfinance
 requests
 python-dotenv
 apscheduler
+pyyaml


### PR DESCRIPTION
## Summary
- add lock_minutes config in `config/config.yaml`
- implement config loader for lock_minutes
- get lock_minutes from config in `get_live_price` and `main`
- document lock_minutes configuration
- include PyYAML in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --debug` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6888f4fe7aa883229b8a8e491ab84dee