### PR TITLE
Implement API server and DB ticker loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ bandera `--debug`:
 python main.py --debug
 ```
 
+7. Levantar la API local
+
+```bash
+python -m api.server
+```
+
 ### Uso de la lógica de fetching
 
 Luego de inicializar las bases de datos, podés obtener precios de forma manual

--- a/api/server.py
+++ b/api/server.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI, HTTPException
+
+from config import get_lock_minutes
+from fetchers import YFinanceFetcher, DummyFetcher
+from .live import get_live_price
+
+app = FastAPI()
+
+try:
+    fetcher = YFinanceFetcher() if YFinanceFetcher is not None else DummyFetcher()
+except Exception:
+    fetcher = DummyFetcher()
+
+
+@app.get("/price/{ticker}")
+def price_endpoint(ticker: str):
+    price = get_live_price(ticker, fetcher, lock_minutes=get_lock_minutes())
+    if price is None:
+        raise HTTPException(status_code=404, detail="Price not available")
+    return {"ticker": ticker.upper(), "price": price}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="127.0.0.1", port=8000)
+

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import argparse
 from fetchers import DummyFetcher
 from api import get_live_price
 from config import get_lock_minutes
+from storage import live as live_db
 from scripts import init_db
 
 
@@ -19,8 +20,11 @@ def main() -> None:
     fetcher = DummyFetcher()
     lock_minutes = get_lock_minutes()
 
-    for ticker in ["AAPL", "MSFT", "GGAL"]:
-        price = get_live_price(ticker, fetcher, lock_minutes=lock_minutes, debug=args.debug)
+    tickers = live_db.list_tickers()
+    for ticker in tickers:
+        price = get_live_price(
+            ticker, fetcher, lock_minutes=lock_minutes, debug=args.debug
+        )
         print(ticker, price)
 
 

--- a/storage/live.py
+++ b/storage/live.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import sqlite3
 from datetime import datetime
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 DB_FILE = Path(__file__).resolve().parent / "live.db"
 
@@ -37,6 +37,16 @@ def get_price(ticker: str) -> Optional[Tuple[float, datetime]]:
         price, ts = row
         return price, datetime.fromisoformat(ts)
     return None
+
+
+def list_tickers() -> List[str]:
+    """Return all tickers currently stored in the database."""
+    conn = sqlite3.connect(DB_FILE)
+    c = conn.cursor()
+    c.execute("SELECT ticker FROM prices")
+    tickers = [r[0] for r in c.fetchall()]
+    conn.close()
+    return tickers
 
 
 def upsert_price(ticker: str, price: float, timestamp: Optional[datetime] = None) -> None:


### PR DESCRIPTION
## Summary
- update README with instructions to run API
- iterate over DB tickers in `main.py`
- expose helper to list stored tickers
- add basic FastAPI app for querying prices

## Testing
- `python -m py_compile main.py api/server.py storage/live.py api/live.py`

------
https://chatgpt.com/codex/tasks/task_e_6888f71e1af883228dcb4dcee5616538