### PR TITLE
Add updated_at timestamp to live price responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ curl http://127.0.0.1:8000/price/AAPL
 La respuesta será un JSON similar a:
 
 ```json
-{"ticker": "AAPL", "price": 123.45}
+{"ticker": "AAPL", "price": 123.45, "updated_at": "2023-01-01T12:00:00Z"}
 ```
 
 ### Uso de la lógica de fetching
@@ -173,8 +173,8 @@ from scripts.init_db import main as init_db
 
 init_db()
 fetcher = DummyFetcher()
-price = get_live_price("AAPL", fetcher)
-print(price)
+price, updated_at = get_live_price("AAPL", fetcher)
+print(price, updated_at)
 ```
 
 El resultado queda almacenado en `storage/live.db`. Si solicitás nuevamente el
@@ -191,7 +191,7 @@ defecto este valor se obtiene desde `config/config.yaml`. Si establecés
 el almacenado en la base. Podés ajustarlo a tus necesidades:
 
 ```python
-price = get_live_price("AAPL", fetcher, lock_minutes=5)
+price, updated_at = get_live_price("AAPL", fetcher, lock_minutes=5)
 ```
 
 En el archivo `main.py` se muestra un ejemplo que utiliza el valor definido en

--- a/api/server.py
+++ b/api/server.py
@@ -14,10 +14,15 @@ except Exception:
 
 @app.get("/price/{ticker}")
 def price_endpoint(ticker: str):
-    price = get_live_price(ticker, fetcher, lock_minutes=get_lock_minutes())
-    if price is None:
+    result = get_live_price(ticker, fetcher, lock_minutes=get_lock_minutes())
+    if result is None:
         raise HTTPException(status_code=404, detail="Price not available")
-    return {"ticker": ticker.upper(), "price": price}
+    price, updated_at = result
+    return {
+        "ticker": ticker.upper(),
+        "price": price,
+        "updated_at": updated_at.isoformat() + "Z",
+    }
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -22,10 +22,14 @@ def main() -> None:
 
     tickers = live_db.list_tickers()
     for ticker in tickers:
-        price = get_live_price(
+        result = get_live_price(
             ticker, fetcher, lock_minutes=lock_minutes, debug=args.debug
         )
-        print(ticker, price)
+        if result is None:
+            print(ticker, "N/A")
+        else:
+            price, updated_at = result
+            print(ticker, price, updated_at.isoformat() + "Z")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update `get_live_price` to return `(price, updated_at)`
- include timestamp in API `/price` endpoint responses
- adapt CLI example in `main.py`
- document new API JSON structure in README

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6888ffeb82e8832287ee44fb2296bdbe