### PR TITLE
Allow API server port from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,14 @@ python main.py --debug
 ```bash
 python -m api.server
 ```
+El host y el puerto utilizados por la API se pueden ajustar en
+`config/config.yaml`.
 
 8. Consultar la API
 
-Una vez levantado el servidor (por defecto en `http://127.0.0.1:8000`), podés
-obtener el precio de un ticker usando `curl`:
+Una vez levantado el servidor (la dirección y el puerto se definen en
+`config/config.yaml`, por defecto `http://127.0.0.1:8000`), podés obtener el
+precio de un ticker usando `curl`:
 
 ```bash
 curl http://127.0.0.1:8000/price/AAPL

--- a/api/server.py
+++ b/api/server.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, HTTPException
 
-from config import get_lock_minutes
+from config import get_lock_minutes, get_server_host, get_server_port
 from fetchers import YFinanceFetcher, DummyFetcher
 from .live import get_live_price
 
@@ -28,5 +28,5 @@ def price_endpoint(ticker: str):
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="127.0.0.1", port=8000)
+    uvicorn.run(app, host=get_server_host(), port=get_server_port())
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -23,5 +23,24 @@ def get_lock_minutes() -> int:
     return int(cfg.get("lock_minutes", 15))
 
 
-__all__ = ["get_lock_minutes"]
+
+def get_server_host() -> str:
+    """Return the API server host from the configuration file."""
+    cfg = _load_config()
+    server = cfg.get("server", {})
+    return str(server.get("host", "127.0.0.1"))
+
+
+def get_server_port() -> int:
+    """Return the API server port from the configuration file."""
+    cfg = _load_config()
+    server = cfg.get("server", {})
+    return int(server.get("port", 8000))
+
+
+__all__ = [
+    "get_lock_minutes",
+    "get_server_host",
+    "get_server_port",
+]
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,8 @@
 # Configuración de pymrkt
 lock_minutes: 15
+server:
+  host: 127.0.0.1
+  port: 8000
 sources:
   - name: yfinance
     enabled: true


### PR DESCRIPTION
## Summary
- load server host & port from `config.yaml`
- expose `get_server_host` and `get_server_port`
- update README instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889028e5a508322b0f9606ee5f4fc68