### PR TITLE
Add ticker type DB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Cada fuente de precios está representada como un módulo `fetcher`, que impleme
 
 ```python
 class PriceFetcher:
-    def get_price(self, ticker: str) -> Optional[float]: ...
+    def get_price(self, ticker: str, ticker_type: Optional[str] = None) -> Optional[float]: ...
     def get_history(self, ticker: str, start: date, end: date) -> List[Tuple[date, float]]: ...
 ```
 
@@ -154,7 +154,10 @@ Una vez levantado el servidor (la dirección y el puerto se definen en
 precio de un ticker usando `curl`:
 
 ```bash
+# Por defecto
 curl http://127.0.0.1:8000/price/AAPL
+# Con tipo de ticker (por ejemplo "acciones")
+curl http://127.0.0.1:8000/price/acciones/AAPL
 ```
 
 La respuesta será un JSON similar a:
@@ -176,11 +179,11 @@ from scripts.init_db import main as init_db
 
 init_db()
 fetcher = DummyFetcher()
-price, updated_at = get_live_price("AAPL", fetcher)
+price, updated_at = get_live_price("AAPL", fetcher, ticker_type="acciones")
 print(price, updated_at)
 ```
 
-El resultado queda almacenado en `storage/live.db`. Si solicitás nuevamente el
+El resultado queda almacenado en `storage/live.acciones.db`. Si solicitás nuevamente el
 precio antes de que pasen 15 minutos (valor configurable con `lock_minutes` en
 `config/config.yaml`), se devolverá el último precio guardado sin contactar al
 *fetcher*.
@@ -194,7 +197,9 @@ defecto este valor se obtiene desde `config/config.yaml`. Si establecés
 el almacenado en la base. Podés ajustarlo a tus necesidades:
 
 ```python
-price, updated_at = get_live_price("AAPL", fetcher, lock_minutes=5)
+price, updated_at = get_live_price(
+    "AAPL", fetcher, lock_minutes=5, ticker_type="acciones"
+)
 ```
 
 En el archivo `main.py` se muestra un ejemplo que utiliza el valor definido en

--- a/api/server.py
+++ b/api/server.py
@@ -12,6 +12,21 @@ except Exception:
     fetcher = DummyFetcher()
 
 
+@app.get("/price/{ticker_type}/{ticker}")
+def price_with_type_endpoint(ticker_type: str, ticker: str):
+    result = get_live_price(
+        ticker, fetcher, lock_minutes=get_lock_minutes(), ticker_type=ticker_type
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Price not available")
+    price, updated_at = result
+    return {
+        "ticker": ticker.upper(),
+        "price": price,
+        "updated_at": updated_at.isoformat() + "Z",
+    }
+
+
 @app.get("/price/{ticker}")
 def price_endpoint(ticker: str):
     result = get_live_price(ticker, fetcher, lock_minutes=get_lock_minutes())

--- a/fetchers/base.py
+++ b/fetchers/base.py
@@ -6,6 +6,11 @@ class PriceFetcher(ABC):
     """Interface for price fetchers."""
 
     @abstractmethod
-    def get_price(self, ticker: str) -> Optional[float]:
-        """Return latest price for ticker or None if not available."""
+    def get_price(self, ticker: str, ticker_type: Optional[str] = None) -> Optional[float]:
+        """Return latest price for ``ticker`` or ``None`` if not available.
+
+        ``ticker_type`` allows fetchers to adjust the query depending on the
+        type of asset (e.g. ``"acciones"`` or ``"cedears"``). Unsupported
+        types should return ``None``.
+        """
         raise NotImplementedError

--- a/fetchers/dummy_fetcher.py
+++ b/fetchers/dummy_fetcher.py
@@ -7,5 +7,5 @@ from .base import PriceFetcher
 class DummyFetcher(PriceFetcher):
     """Return a random price for testing purposes."""
 
-    def get_price(self, ticker: str) -> Optional[float]:
+    def get_price(self, ticker: str, ticker_type: Optional[str] = None) -> Optional[float]:
         return round(random.uniform(1, 100), 2)

--- a/fetchers/yfinance_fetcher.py
+++ b/fetchers/yfinance_fetcher.py
@@ -7,7 +7,13 @@ from .base import PriceFetcher
 class YFinanceFetcher(PriceFetcher):
     """Fetch prices using yfinance."""
 
-    def get_price(self, ticker: str) -> Optional[float]:
+    def get_price(self, ticker: str, ticker_type: Optional[str] = None) -> Optional[float]:
+        if ticker_type in {"acciones", "cedears"}:
+            ticker = f"{ticker}.BA"
+        elif ticker_type not in {None, "acciones", "cedears"}:
+            # Unsupported ticker type
+            return None
+
         try:
             data = yf.Ticker(ticker)
             price = data.info.get("regularMarketPrice")


### PR DESCRIPTION
## Summary
- add ticker_type parameter to fetchers and API
- extend `storage.live` to manage separate databases for acciones, cedears and bonos
- fetch `.BA` tickers via `YFinanceFetcher` when needed
- expose new `/price/{ticker_type}/{ticker}` route
- update docs with new usage examples

## Testing
- `python -m py_compile api/live.py api/server.py fetchers/base.py fetchers/dummy_fetcher.py fetchers/yfinance_fetcher.py storage/live.py main.py scripts/init_db.py`

------
https://chatgpt.com/codex/tasks/task_e_68891a53836c8322b7bda7d15baa1583