### PR TITLE
Add Banco Piano bond fetcher and multi-source support

### DIFF
--- a/fetchers/__init__.py
+++ b/fetchers/__init__.py
@@ -4,8 +4,13 @@ from .base import PriceFetcher
 from .dummy_fetcher import DummyFetcher
 
 try:
+    from .banco_piano_fetcher import BancoPianoFetcher
+except Exception:  # pragma: no cover - optional dependency
+    BancoPianoFetcher = None
+
+try:
     from .yfinance_fetcher import YFinanceFetcher
 except Exception:  # pragma: no cover - optional dependency
     YFinanceFetcher = None
 
-__all__ = ["PriceFetcher", "DummyFetcher", "YFinanceFetcher"]
+__all__ = ["PriceFetcher", "DummyFetcher", "YFinanceFetcher", "BancoPianoFetcher"]

--- a/fetchers/banco_piano_fetcher.py
+++ b/fetchers/banco_piano_fetcher.py
@@ -1,0 +1,55 @@
+import requests
+import pandas as pd
+from typing import Optional, List, Tuple
+
+from .base import PriceFetcher
+
+
+class BancoPianoFetcher(PriceFetcher):
+    """Fetch bond prices from Banco Piano."""
+
+    URL = "https://www.bancopiano.com.ar/Inversiones/Cotizaciones/Bonos/"
+
+    def __init__(self) -> None:
+        self._df = None
+
+    def _load_dataframe(self) -> None:
+        if self._df is not None:
+            return
+        try:
+            resp = requests.get(self.URL)
+            resp.raise_for_status()
+            tables = pd.read_html(resp.text)
+            self._df = tables[0] if tables else None
+        except Exception:
+            self._df = None
+
+    def get_price(self, ticker: str, ticker_type: Optional[str] = None) -> Optional[float]:
+        if ticker_type not in {None, "bonos"}:
+            return None
+        self._load_dataframe()
+        if self._df is None or self._df.empty:
+            return None
+        ticker = ticker.upper()
+        try:
+            mask = self._df.iloc[:, 0].astype(str).str.contains(ticker, case=False, na=False)
+            row = self._df.loc[mask]
+            if row.empty:
+                return None
+            # find column containing "VENTA"
+            venta_col = None
+            for col in self._df.columns:
+                if "VENTA" in str(col).upper():
+                    venta_col = col
+                    break
+            if venta_col is None:
+                return None
+            value = str(row.iloc[0][venta_col])
+            value = value.replace(".", "").replace(",", ".")
+            return float(value)
+        except Exception:
+            return None
+
+    def get_history(self, *args, **kwargs) -> List[Tuple]:
+        """Historical data not supported for this source."""
+        return []

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-from fetchers import YFinanceFetcher
+from fetchers import YFinanceFetcher, DummyFetcher, BancoPianoFetcher
 from api import get_live_price
 from config import get_lock_minutes
 from storage import live as live_db
@@ -17,13 +17,23 @@ def main() -> None:
     args = parser.parse_args()
 
     init_db.main()
-    fetcher = YFinanceFetcher()
+    fetchers = []
+    try:
+        fetchers.append(YFinanceFetcher())
+    except Exception:
+        pass
+    try:
+        fetchers.append(BancoPianoFetcher())
+    except Exception:
+        pass
+    if not fetchers:
+        fetchers.append(DummyFetcher())
     lock_minutes = get_lock_minutes()
 
     tickers = live_db.list_tickers()
     for ticker in tickers:
         result = get_live_price(
-            ticker, fetcher, lock_minutes=lock_minutes, debug=args.debug
+            ticker, fetchers, lock_minutes=lock_minutes, debug=args.debug
         )
         if result is None:
             print(ticker, "N/A")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests
 python-dotenv
 apscheduler
 pyyaml
+pandas


### PR DESCRIPTION
## Summary
- add BancoPianoFetcher for live bond prices
- allow get_live_price to combine multiple fetchers and use median
- enable multiple fetchers in FastAPI server and entrypoint
- expose `/bonos/{ticker}` endpoint
- require `pandas`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688932bb2cec8322a94ee2b3875f519f