### PR TITLE
Add supported_ticker_types attribute for fetchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Cada fuente de precios está representada como un módulo `fetcher`, que impleme
 
 ```python
 class PriceFetcher:
+    supported_ticker_types: Tuple[Optional[str], ...]
     def get_price(self, ticker: str, ticker_type: Optional[str] = None) -> Optional[float]: ...
     def get_history(self, ticker: str, start: date, end: date) -> List[Tuple[date, float]]: ...
 ```

--- a/fetchers/banco_piano_fetcher.py
+++ b/fetchers/banco_piano_fetcher.py
@@ -8,6 +8,9 @@ from .base import PriceFetcher
 class BancoPianoFetcher(PriceFetcher):
     """Fetch bond prices from Banco Piano."""
 
+    #: Banco Piano solo publica precios de bonos
+    supported_ticker_types = ("bonos",)
+
     URL = "https://www.bancopiano.com.ar/Inversiones/Cotizaciones/Bonos/"
 
     def __init__(self) -> None:

--- a/fetchers/base.py
+++ b/fetchers/base.py
@@ -3,7 +3,15 @@ from typing import Optional
 
 
 class PriceFetcher(ABC):
-    """Interface for price fetchers."""
+    """Interface for price fetchers.
+
+    Subclasses should define :pyattr:`supported_ticker_types` listing the
+    ``ticker_type`` values they can handle. ``None`` indicates that the fetcher
+    supports queries where no ticker type was specified.
+    """
+
+    #: Tuple of supported ticker types. ``None`` means "no type provided".
+    supported_ticker_types: tuple[Optional[str], ...] = (None,)
 
     @abstractmethod
     def get_price(self, ticker: str, ticker_type: Optional[str] = None) -> Optional[float]:

--- a/fetchers/dummy_fetcher.py
+++ b/fetchers/dummy_fetcher.py
@@ -7,5 +7,8 @@ from .base import PriceFetcher
 class DummyFetcher(PriceFetcher):
     """Return a random price for testing purposes."""
 
+    #: Acepta cualquier tipo de ticker para fines de prueba
+    supported_ticker_types = (None, "acciones", "cedears", "bonos")
+
     def get_price(self, ticker: str, ticker_type: Optional[str] = None) -> Optional[float]:
         return round(random.uniform(1, 100), 2)

--- a/fetchers/yfinance_fetcher.py
+++ b/fetchers/yfinance_fetcher.py
@@ -7,6 +7,9 @@ from .base import PriceFetcher
 class YFinanceFetcher(PriceFetcher):
     """Fetch prices using yfinance."""
 
+    #: Admite acciones, CEDEARs y consultas sin tipo especificado
+    supported_ticker_types = (None, "acciones", "cedears")
+
     def get_price(self, ticker: str, ticker_type: Optional[str] = None) -> Optional[float]:
         if ticker_type in {"acciones", "cedears"}:
             ticker = f"{ticker}.BA"


### PR DESCRIPTION
## Summary
- document supported ticker types for each fetcher
- list supported ticker types in README example

## Testing
- `python -m compileall -q fetchers storage api config scripts`
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68893503b7b88322bcfb57d4cc238d4e