### PR TITLE
Improve fetcher filtering and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,23 @@ price, updated_at = get_live_price(
 En el archivo `main.py` se muestra un ejemplo que utiliza el valor definido en
 `config/config.yaml` para reducir la cantidad de llamadas externas.
 
+### Uso simultáneo de varios fetchers
+
+`get_live_price` también acepta una lista de *fetchers*. Podés activar varios a
+la vez y el sistema usará solo aquellos que soporten el tipo de ticker
+solicitado. Por ejemplo, combinando `YFinanceFetcher` con `BancoPianoFetcher`:
+
+```python
+from fetchers import YFinanceFetcher, BancoPianoFetcher
+from api.live import get_live_price
+
+fetchers = [YFinanceFetcher(), BancoPianoFetcher()]
+price, updated_at = get_live_price("AL30", fetchers, ticker_type="bonos")
+```
+
+La función filtrará automáticamente los *fetchers* para que cada consulta se
+realice solo a las fuentes adecuadas.
+
 ---
 
 ## 🔐 Seguridad

--- a/api/live.py
+++ b/api/live.py
@@ -41,6 +41,20 @@ def get_live_price(
     else:
         fetchers = list(fetcher)
 
+    # Only use fetchers that support the requested ticker type
+    if ticker_type is None:
+        fetchers = [
+            f
+            for f in fetchers
+            if None in getattr(f, "supported_ticker_types", (None,))
+        ]
+    else:
+        fetchers = [
+            f
+            for f in fetchers
+            if ticker_type in getattr(f, "supported_ticker_types", ())
+        ]
+
     prices = []
     for f in fetchers:
         p = f.get_price(ticker, ticker_type)


### PR DESCRIPTION
## Summary
- filter fetchers in `get_live_price` to use only those that support the requested ticker type
- document how to enable multiple fetchers at once in README

## Testing
- `python -m py_compile api/live.py`
- `python -m py_compile fetchers/*.py`
- `python -m py_compile main.py api/server.py scripts/init_db.py storage/*.py config/*.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688936edc6e08322add44e7dfc51aa71