### PR TITLE
Add Data912Fetcher for bond prices

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -1,7 +1,12 @@
 from fastapi import FastAPI, HTTPException
 
 from config import get_lock_minutes, get_server_host, get_server_port
-from fetchers import YFinanceFetcher, DummyFetcher, BancoPianoFetcher
+from fetchers import (
+    YFinanceFetcher,
+    DummyFetcher,
+    BancoPianoFetcher,
+    Data912Fetcher,
+)
 from .live import get_live_price
 
 app = FastAPI()
@@ -10,6 +15,12 @@ fetchers = []
 try:
     if YFinanceFetcher is not None:
         fetchers.append(YFinanceFetcher())
+except Exception:
+    pass
+
+try:
+    if Data912Fetcher is not None:
+        fetchers.append(Data912Fetcher())
 except Exception:
     pass
 

--- a/fetchers/__init__.py
+++ b/fetchers/__init__.py
@@ -4,6 +4,11 @@ from .base import PriceFetcher
 from .dummy_fetcher import DummyFetcher
 
 try:
+    from .data912_fetcher import Data912Fetcher
+except Exception:  # pragma: no cover - optional dependency
+    Data912Fetcher = None
+
+try:
     from .banco_piano_fetcher import BancoPianoFetcher
 except Exception:  # pragma: no cover - optional dependency
     BancoPianoFetcher = None
@@ -13,4 +18,10 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     YFinanceFetcher = None
 
-__all__ = ["PriceFetcher", "DummyFetcher", "YFinanceFetcher", "BancoPianoFetcher"]
+__all__ = [
+    "PriceFetcher",
+    "DummyFetcher",
+    "YFinanceFetcher",
+    "BancoPianoFetcher",
+    "Data912Fetcher",
+]

--- a/fetchers/data912_fetcher.py
+++ b/fetchers/data912_fetcher.py
@@ -1,0 +1,61 @@
+import logging
+from datetime import datetime, date
+from typing import Optional, List, Tuple
+
+import requests
+
+from .base import PriceFetcher
+from storage import live as live_db
+
+logger = logging.getLogger(__name__)
+
+
+class Data912Fetcher(PriceFetcher):
+    """Fetch Argentine bond prices from the public Data912 API."""
+
+    #: Data912 provides only bonds prices
+    supported_ticker_types = ("bonos",)
+
+    URL = "https://data912.com/live/arg_bonds"
+
+    def get_price(self, ticker: str, ticker_type: Optional[str] = None) -> Optional[float]:
+        """Return last traded price for ``ticker`` using Data912.
+
+        All retrieved bonds are stored in ``live.bonos.db`` for reuse.
+        """
+        if ticker_type not in {None, "bonos"}:
+            return None
+
+        try:
+            resp = requests.get(self.URL, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Data912 request failed: %s", exc)
+            return None
+
+        if not isinstance(data, list):
+            return None
+
+        now = datetime.utcnow()
+        db_file = live_db.get_db_file("bonos")
+        result_price = None
+
+        for item in data:
+            symbol = item.get("symbol")
+            close = item.get("c")
+            if symbol is None or close is None:
+                continue
+            try:
+                price = float(close)
+            except Exception:  # noqa: BLE001
+                continue
+            live_db.upsert_price(symbol, price, timestamp=now, db_file=db_file)
+            if symbol == ticker:
+                result_price = price
+
+        return result_price
+
+    def get_history(self, ticker: str, start: date, end: date) -> List[Tuple[date, float]]:
+        """Historical data is not supported for Data912."""
+        return []

--- a/main.py
+++ b/main.py
@@ -2,7 +2,12 @@
 
 import argparse
 
-from fetchers import YFinanceFetcher, DummyFetcher, BancoPianoFetcher
+from fetchers import (
+    YFinanceFetcher,
+    DummyFetcher,
+    BancoPianoFetcher,
+    Data912Fetcher,
+)
 from api import get_live_price
 from config import get_lock_minutes
 from storage import live as live_db
@@ -20,6 +25,10 @@ def main() -> None:
     fetchers = []
     try:
         fetchers.append(YFinanceFetcher())
+    except Exception:
+        pass
+    try:
+        fetchers.append(Data912Fetcher())
     except Exception:
         pass
     try:


### PR DESCRIPTION
## Summary
- implement Data912Fetcher to retrieve bond data from https://data912.com/live/arg_bonds
- store all fetched bonds in `live.bonos.db`
- expose Data912Fetcher via `fetchers` package
- use Data912Fetcher in API server and main CLI

## Testing
- `python -m py_compile fetchers/data912_fetcher.py fetchers/__init__.py api/server.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_688abd8d6db08322973c96766549b1fe