### PR TITLE
Add DolarApiFetcher and currency db

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -2,11 +2,13 @@ from fastapi import FastAPI, HTTPException
 
 from config import get_lock_minutes, get_server_host, get_server_port
 from fetchers import (
-    YFinanceFetcher,
-    DummyFetcher,
     BancoPianoFetcher,
     Data912Fetcher,
+    DolarApiFetcher,
+    DummyFetcher,
+    YFinanceFetcher,
 )
+
 from .live import get_live_price
 
 app = FastAPI()
@@ -21,6 +23,12 @@ except Exception:
 try:
     if Data912Fetcher is not None:
         fetchers.append(Data912Fetcher())
+except Exception:
+    pass
+
+try:
+    if DolarApiFetcher is not None:
+        fetchers.append(DolarApiFetcher())
 except Exception:
     pass
 
@@ -71,4 +79,3 @@ if __name__ == "__main__":
     import uvicorn
 
     uvicorn.run(app, host=get_server_host(), port=get_server_port())
-

--- a/fetchers/__init__.py
+++ b/fetchers/__init__.py
@@ -4,6 +4,11 @@ from .base import PriceFetcher
 from .dummy_fetcher import DummyFetcher
 
 try:
+    from .dolarapi_fetcher import DolarApiFetcher
+except Exception:  # pragma: no cover - optional dependency
+    DolarApiFetcher = None
+
+try:
     from .data912_fetcher import Data912Fetcher
 except Exception:  # pragma: no cover - optional dependency
     Data912Fetcher = None
@@ -24,4 +29,5 @@ __all__ = [
     "YFinanceFetcher",
     "BancoPianoFetcher",
     "Data912Fetcher",
+    "DolarApiFetcher",
 ]

--- a/fetchers/data912_fetcher.py
+++ b/fetchers/data912_fetcher.py
@@ -1,11 +1,12 @@
 import logging
-from datetime import datetime, date
-from typing import Optional, List, Tuple
+from datetime import date, datetime
+from typing import List, Optional, Tuple
 
 import requests
 
-from .base import PriceFetcher
 from storage import live as live_db
+
+from .base import PriceFetcher
 
 logger = logging.getLogger(__name__)
 
@@ -18,12 +19,14 @@ class Data912Fetcher(PriceFetcher):
 
     URL = "https://data912.com/live/arg_bonds"
 
-    def get_price(self, ticker: str, ticker_type: Optional[str] = None) -> Optional[float]:
+    def get_price(
+        self, ticker: str, ticker_type: Optional[str] = None
+    ) -> Optional[float]:
         """Return last traded price for ``ticker`` using Data912.
 
         All retrieved bonds are stored in ``live.bonos.db`` for reuse.
         """
-        if ticker_type not in {None, "bonos"}:
+        if ticker_type != "bonos":
             return None
 
         try:
@@ -56,6 +59,8 @@ class Data912Fetcher(PriceFetcher):
 
         return result_price
 
-    def get_history(self, ticker: str, start: date, end: date) -> List[Tuple[date, float]]:
+    def get_history(
+        self, ticker: str, start: date, end: date
+    ) -> List[Tuple[date, float]]:
         """Historical data is not supported for Data912."""
         return []

--- a/fetchers/dolarapi_fetcher.py
+++ b/fetchers/dolarapi_fetcher.py
@@ -1,0 +1,40 @@
+import logging
+from typing import List, Optional, Tuple
+
+import requests
+
+from .base import PriceFetcher
+
+logger = logging.getLogger(__name__)
+
+
+class DolarApiFetcher(PriceFetcher):
+    """Fetch USD price from dolarapi.com."""
+
+    #: Supports only USD under ticker type "monedas"
+    supported_ticker_types = ("monedas",)
+
+    URL = "https://dolarapi.com/v1/dolares/bolsa"
+
+    def get_price(
+        self, ticker: str, ticker_type: Optional[str] = None
+    ) -> Optional[float]:
+        if ticker_type != "monedas" or ticker.upper() != "USD":
+            return None
+        try:
+            resp = requests.get(self.URL, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            compra = data.get("compra")
+            venta = data.get("venta")
+            if compra is None or venta is None:
+                return None
+            avg = (float(compra) + float(venta)) / 2
+            return round(avg, 2)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("dolarapi request failed: %s", exc)
+            return None
+
+    def get_history(self, *args, **kwargs) -> List[Tuple]:
+        """Historical data not provided by this API."""
+        return []

--- a/main.py
+++ b/main.py
@@ -2,23 +2,22 @@
 
 import argparse
 
-from fetchers import (
-    YFinanceFetcher,
-    DummyFetcher,
-    BancoPianoFetcher,
-    Data912Fetcher,
-)
 from api import get_live_price
 from config import get_lock_minutes
-from storage import live as live_db
+from fetchers import (
+    BancoPianoFetcher,
+    Data912Fetcher,
+    DolarApiFetcher,
+    DummyFetcher,
+    YFinanceFetcher,
+)
 from scripts import init_db
+from storage import live as live_db
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run pymrkt")
-    parser.add_argument(
-        "--debug", action="store_true", help="Enable debug output"
-    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug output")
     args = parser.parse_args()
 
     init_db.main()
@@ -29,6 +28,10 @@ def main() -> None:
         pass
     try:
         fetchers.append(Data912Fetcher())
+    except Exception:
+        pass
+    try:
+        fetchers.append(DolarApiFetcher())
     except Exception:
         pass
     try:

--- a/storage/live.py
+++ b/storage/live.py
@@ -1,7 +1,7 @@
-from pathlib import Path
 import sqlite3
 from datetime import datetime
-from typing import Optional, Tuple, List, Union
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
 
 BASE_PATH = Path(__file__).resolve().parent
 
@@ -9,6 +9,7 @@ DEFAULT_DB_FILE = BASE_PATH / "live.db"
 ACCIONES_DB_FILE = BASE_PATH / "live.acciones.db"
 CEDEARS_DB_FILE = BASE_PATH / "live.cedears.db"
 BONOS_DB_FILE = BASE_PATH / "live.bonos.db"
+MONEDAS_DB_FILE = BASE_PATH / "live.monedas.db"
 
 
 def get_db_file(ticker_type: Optional[str] = None) -> Path:
@@ -19,6 +20,8 @@ def get_db_file(ticker_type: Optional[str] = None) -> Path:
         return CEDEARS_DB_FILE
     if ticker_type == "bonos":
         return BONOS_DB_FILE
+    if ticker_type == "monedas":
+        return MONEDAS_DB_FILE
     return DEFAULT_DB_FILE
 
 
@@ -40,11 +43,19 @@ def _init_table(db_file: Union[str, Path]) -> None:
 
 def init_db() -> None:
     """Create the live price tables if they don't exist."""
-    for db in [DEFAULT_DB_FILE, ACCIONES_DB_FILE, CEDEARS_DB_FILE, BONOS_DB_FILE]:
+    for db in [
+        DEFAULT_DB_FILE,
+        ACCIONES_DB_FILE,
+        CEDEARS_DB_FILE,
+        BONOS_DB_FILE,
+        MONEDAS_DB_FILE,
+    ]:
         _init_table(db)
 
 
-def get_price(ticker: str, db_file: Optional[Union[str, Path]] = None) -> Optional[Tuple[float, datetime]]:
+def get_price(
+    ticker: str, db_file: Optional[Union[str, Path]] = None
+) -> Optional[Tuple[float, datetime]]:
     """Return price and timestamp for ticker if available."""
     if db_file is None:
         db_file = DEFAULT_DB_FILE
@@ -74,7 +85,12 @@ def list_tickers(db_file: Optional[Union[str, Path]] = None) -> List[str]:
     return tickers
 
 
-def upsert_price(ticker: str, price: float, timestamp: Optional[datetime] = None, db_file: Optional[Union[str, Path]] = None) -> None:
+def upsert_price(
+    ticker: str,
+    price: float,
+    timestamp: Optional[datetime] = None,
+    db_file: Optional[Union[str, Path]] = None,
+) -> None:
     """Insert or update price for ticker."""
     if timestamp is None:
         timestamp = datetime.utcnow()


### PR DESCRIPTION
## Summary
- add `DolarApiFetcher` for USD price via dolarapi.com
- store currency data in new `live.monedas.db`
- expose DolarApiFetcher in server and CLI
- limit `Data912Fetcher` to ticker type `bonos`

## Testing
- `black fetchers/dolarapi_fetcher.py fetchers/__init__.py api/server.py main.py storage/live.py fetchers/data912_fetcher.py`
- `isort fetchers/dolarapi_fetcher.py fetchers/__init__.py api/server.py main.py storage/live.py fetchers/data912_fetcher.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ac22840908322bf2aae3a2750ed7c