### PR TITLE
Initialize DB automatically on API startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,10 @@ export DOLAR_SCRAPER_API_KEY=clave123
 export SECRET_API_KEY=clave321
 ```
 
-5. Inicializar la base
+5. (Opcional) Inicializar la base manualmente
+
+El servidor crea las tablas automáticamente al iniciar, por lo que este paso es
+generalmente innecesario.
 
 ```bash
 python scripts/init_db.py
@@ -145,8 +148,7 @@ python main.py --debug
 ```bash
 python -m api.server
 ```
-El host y el puerto utilizados por la API se pueden ajustar en
-`config/config.yaml`.
+Al iniciarse, el servidor crea automáticamente las tablas necesarias en las bases de datos, por lo que no es obligatorio ejecutar `scripts/init_db.py` de forma previa. El host y el puerto utilizados por la API se pueden ajustar en `config/config.yaml`.
 
 8. Consultar la API
 

--- a/api/server.py
+++ b/api/server.py
@@ -9,7 +9,11 @@ from fetchers import (
     YFinanceFetcher,
 )
 
+from storage import live as live_db
+
 from .live import get_live_price
+
+live_db.init_db()
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- initialize database automatically when starting `api.server`
- describe automatic DB initialization in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688ac42d6e0c832284ab266fb9ae85e7