### PR TITLE
Add historical price endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,16 @@ archivo YAML (`config/config.yaml`).
 
 Usamos FastAPI para exponer:
 
-- `GET /precio/<ticker>`  
+- `GET /price/<ticker>`
   Último precio disponible.
 
-- `GET /historial/<ticker>?desde=YYYY-MM-DD&hasta=YYYY-MM-DD`  
+- `GET /historial/<ticker>?desde=YYYY-MM-DD&hasta=YYYY-MM-DD`
   Histórico de precios.
 
-- `GET /batch?ticker=YPF,AAPL`  
+- `GET /batch?ticker=YPF,AAPL`
   Precios recientes de múltiples tickers.
 
-- `GET /status`  
+- `GET /status`
   Estado del sistema.
 
 ---
@@ -161,6 +161,8 @@ precio de un ticker usando `curl`:
 curl http://127.0.0.1:8000/price/AAPL
 # Con tipo de ticker (por ejemplo "acciones")
 curl http://127.0.0.1:8000/price/acciones/AAPL
+# Historial entre dos fechas
+curl "http://127.0.0.1:8000/historial/AAPL?desde=2023-01-01&hasta=2023-01-31"
 ```
 
 La respuesta será un JSON similar a:

--- a/api/history.py
+++ b/api/history.py
@@ -1,0 +1,22 @@
+from datetime import date
+from typing import List, Dict
+
+from storage import historical as historical_db
+
+
+def get_historical_prices(ticker: str, start: date, end: date) -> List[Dict[str, object]]:
+    """Return historical prices for ``ticker`` between ``start`` and ``end``.
+
+    The data is fetched from the historical storage and serialised to JSON-
+    friendly dictionaries.
+    """
+    records = historical_db.get_history(ticker, start, end)
+    return [
+        {
+            "date": d.isoformat(),
+            "price": price,
+            "adj_price": adj_price,
+            "volume": volume,
+        }
+        for d, price, adj_price, volume in records
+    ]

--- a/api/server.py
+++ b/api/server.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from fastapi import FastAPI, HTTPException
 
 from config import get_lock_minutes, get_server_host, get_server_port
@@ -10,10 +12,13 @@ from fetchers import (
 )
 
 from storage import live as live_db
+from storage import historical as historical_db
 
 from .live import get_live_price
+from .history import get_historical_prices
 
 live_db.init_db()
+historical_db.init_db()
 
 app = FastAPI()
 
@@ -77,6 +82,14 @@ def price_endpoint(ticker: str):
         "price": price,
         "updated_at": updated_at.isoformat() + "Z",
     }
+
+
+@app.get("/historial/{ticker}")
+def history_endpoint(ticker: str, desde: date, hasta: date):
+    history = get_historical_prices(ticker, desde, hasta)
+    if not history:
+        raise HTTPException(status_code=404, detail="History not available")
+    return {"ticker": ticker.upper(), "history": history}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expose `/historial/{ticker}` endpoint with `desde`/`hasta` query params
- provide helper to fetch and format historical records
- document history endpoint in README

## Testing
- `python -m py_compile api/server.py api/history.py storage/historical.py`
- `pytest`
- `curl "http://127.0.0.1:8001/historial/AAPL?desde=2023-01-01&hasta=2023-01-02"`


------
https://chatgpt.com/codex/tasks/task_e_68b58ba1eed08322a2eeca9972edcad3