### PR TITLE
Add historical price support for fetchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,9 @@ curl "http://127.0.0.1:8000/historial/YPF?desde=2023-01-01&hasta=2023-01-31"
 ```
 
 También podés obtener y almacenar históricos desde Python usando un
-`PriceFetcher` que implemente `get_history`:
+`PriceFetcher` que implemente `get_history`. Los fetchers con soporte
+histórico, como `YFinanceFetcher`, insertan automáticamente cada registro en la
+base `storage/historical.db`:
 
 ```python
 from datetime import date
@@ -253,7 +255,7 @@ historical.init_db()
 fetcher = YFinanceFetcher()
 history = fetcher.get_history("AAPL", date(2023, 1, 1), date(2023, 1, 5))
 for d, price in history:
-    historical.insert_record("AAPL", d, price, price, 0)
+    print(d, price)
 ```
 
 Primero ejecutá `scripts/init_db.py` para crear la base

--- a/fetchers/banco_piano_fetcher.py
+++ b/fetchers/banco_piano_fetcher.py
@@ -3,7 +3,9 @@ import logging
 import re
 import requests
 import pandas as pd
-from typing import Optional, List, Tuple
+import warnings
+from datetime import date
+from typing import List, Optional, Tuple
 
 from .base import PriceFetcher
 
@@ -79,6 +81,7 @@ class BancoPianoFetcher(PriceFetcher):
         except Exception:
             return None
 
-    def get_history(self, *args, **kwargs) -> List[Tuple]:
+    def get_history(self, ticker: str, start: date, end: date) -> List[Tuple[date, float]]:
         """Historical data not supported for this source."""
+        warnings.warn("BancoPianoFetcher does not provide historical data", stacklevel=2)
         return []

--- a/fetchers/base.py
+++ b/fetchers/base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from datetime import date
+from typing import List, Optional, Tuple
 
 
 class PriceFetcher(ABC):
@@ -20,5 +21,14 @@ class PriceFetcher(ABC):
         ``ticker_type`` allows fetchers to adjust the query depending on the
         type of asset (e.g. ``"acciones"`` or ``"cedears"``). Unsupported
         types should return ``None``.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_history(self, ticker: str, start: date, end: date) -> List[Tuple[date, float]]:
+        """Return historical prices for ``ticker`` between ``start`` and ``end``.
+
+        Subclasses that do not implement historical queries should return an
+        empty list and issue a warning.
         """
         raise NotImplementedError

--- a/fetchers/data912_fetcher.py
+++ b/fetchers/data912_fetcher.py
@@ -3,6 +3,7 @@ from datetime import date, datetime
 from typing import List, Optional, Tuple
 
 import requests
+import warnings
 
 from storage import live as live_db
 
@@ -63,4 +64,5 @@ class Data912Fetcher(PriceFetcher):
         self, ticker: str, start: date, end: date
     ) -> List[Tuple[date, float]]:
         """Historical data is not supported for Data912."""
+        warnings.warn("Data912Fetcher does not provide historical data", stacklevel=2)
         return []

--- a/fetchers/dolarapi_fetcher.py
+++ b/fetchers/dolarapi_fetcher.py
@@ -2,6 +2,8 @@ import logging
 from typing import List, Optional, Tuple
 
 import requests
+import warnings
+from datetime import date
 
 from .base import PriceFetcher
 
@@ -35,6 +37,7 @@ class DolarApiFetcher(PriceFetcher):
             logger.debug("dolarapi request failed: %s", exc)
             return None
 
-    def get_history(self, *args, **kwargs) -> List[Tuple]:
+    def get_history(self, ticker: str, start: date, end: date) -> List[Tuple[date, float]]:
         """Historical data not provided by this API."""
+        warnings.warn("DolarApiFetcher does not provide historical data", stacklevel=2)
         return []

--- a/fetchers/dummy_fetcher.py
+++ b/fetchers/dummy_fetcher.py
@@ -1,5 +1,7 @@
-from typing import Optional
+from typing import List, Optional, Tuple
+from datetime import date
 import random
+import warnings
 
 from .base import PriceFetcher
 
@@ -12,3 +14,8 @@ class DummyFetcher(PriceFetcher):
 
     def get_price(self, ticker: str, ticker_type: Optional[str] = None) -> Optional[float]:
         return round(random.uniform(1, 100), 2)
+
+    def get_history(self, ticker: str, start: date, end: date) -> List[Tuple[date, float]]:
+        """Historical data not supported for the dummy fetcher."""
+        warnings.warn("DummyFetcher does not provide historical data", stacklevel=2)
+        return []

--- a/fetchers/yfinance_fetcher.py
+++ b/fetchers/yfinance_fetcher.py
@@ -1,7 +1,10 @@
-from typing import Optional
+from datetime import date
+from typing import List, Optional, Tuple
+import warnings
 import yfinance as yf
 
 from .base import PriceFetcher
+from storage import historical
 
 
 class YFinanceFetcher(PriceFetcher):
@@ -23,3 +26,30 @@ class YFinanceFetcher(PriceFetcher):
             return float(price) if price is not None else None
         except Exception:
             return None
+
+    def get_history(self, ticker: str, start: date, end: date) -> List[Tuple[date, float]]:
+        """Retrieve and store historical prices for ``ticker`` from yfinance."""
+
+        try:
+            history_df = yf.Ticker(ticker).history(start=start, end=end)
+        except Exception:
+            warnings.warn("yfinance request for historical data failed", stacklevel=2)
+            return []
+
+        results: List[Tuple[date, float]] = []
+        for idx, row in history_df.iterrows():
+            d = idx.date()
+            price = float(row.get("Close", float("nan")))
+            if price != price:  # NaN check
+                continue
+            adj_price = row.get("Adj Close")
+            volume = row.get("Volume")
+            historical.insert_record(
+                ticker,
+                d,
+                price,
+                float(adj_price) if adj_price == adj_price else price,
+                int(volume) if volume == volume else 0,
+            )
+            results.append((d, price))
+        return results


### PR DESCRIPTION
## Summary
- add `get_history` method to `PriceFetcher` interface and concrete implementations
- implement yfinance-backed historical retrieval with automatic DB insertion
- document historical usage with examples in README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b58dcf92808322888f371083178b2f